### PR TITLE
Add support for Python 3

### DIFF
--- a/d3po/__init__.py
+++ b/d3po/__init__.py
@@ -13,4 +13,4 @@ app = Flask(__name__)
 github_client = GithubClient()
 github_client.authenticate()
 
-import views
+from . import views


### PR DESCRIPTION
`d3po` only supports *legacy Python* at present due to an implicit relative import in `__init__`.

This PR fixes `d3po` to work with Python 3!